### PR TITLE
Update request format to new api

### DIFF
--- a/godaddy_ddns.ps1
+++ b/godaddy_ddns.ps1
@@ -25,6 +25,6 @@ $currentIp = Invoke-RestMethod http://ipinfo.io/json | Select -exp ip
 if ( $currentIp -ne $dnsIp) {
     $Request = @{ttl=3600;data=$currentIp }
     $JSON = Convertto-Json $request
-    Invoke-WebRequest https://api.godaddy.com/v1/domains/$domain/records/A/$name -method put -headers $headers -Body $json -ContentType "application/json"
+    Invoke-WebRequest https://api.godaddy.com/v1/domains/$domain/records/A/$name -method put -headers $headers -Body [$json] -ContentType "application/json"
 }
 

--- a/updategodaddy.sh
+++ b/updategodaddy.sh
@@ -73,7 +73,7 @@ echo $name"."$domain": $(date): $type: dnsIp:" $dnsIp
 if [ $dnsIp != $currentIp ];
  then
         echo $name"."$domain": $(date): $type: IPs not equal. Updating."
-        request='{"data":"'$currentIp'","ttl":3600}'
+        request='[{"data":"'$currentIp'","ttl":3600}]'
         #echo $request
         nresult=$(curl -i -k -s -X PUT \
  -H "$headers" \


### PR DESCRIPTION
Fix for api change from Godaddy. From now on the request must be wrapped in a list/array.
The old scripts will produce this error:
`{"code":"INVALID_BODY","fields":[{"code":"UNEXPECTED_TYPE","message":"is not a array","path":"records"}],"message":"Request body doesn't fulfill schema, see details in `fields`"}`

